### PR TITLE
Fix for monochrome terminal

### DIFF
--- a/percol/display.py
+++ b/percol/display.py
@@ -106,14 +106,13 @@ class Display(object):
         self.parser   = markup.MarkupParser()
 
         curses.start_color()
-        curses.use_default_colors()
 
         if curses.COLORS > COLOR_COUNT:
+            curses.use_default_colors()
             FG_COLORS["default"]    = -1
             BG_COLORS["on_default"] = -1
             self.init_color_pairs()
         else:
-            self.init_color_pairs()
             FG_COLORS["default"]    = curses.COLOR_WHITE
             BG_COLORS["on_default"] = curses.COLOR_BLACK
 

--- a/percol/theme.py
+++ b/percol/theme.py
@@ -20,6 +20,6 @@
 # see display.py to see available colors and attributes
 
 CANDIDATES_LINE_BASIC    = ("on_default", "default")
-CANDIDATES_LINE_SELECTED = ("on_magenta", "white")
-CANDIDATES_LINE_MARKED   = ("on_cyan", "black")
+CANDIDATES_LINE_SELECTED = ("underline", "on_magenta", "white")
+CANDIDATES_LINE_MARKED   = ("bold", "on_cyan", "black")
 CANDIDATES_LINE_QUERY    = ("yellow", "bold")


### PR DESCRIPTION
In monochrome terminal environment, such as $TERM=vt102, the program fails at curses.use_default_colors() and curses.init_pair(). 
I fix it and modify the default theme.

My Environment: OSX Lion/Python2.7.1/ncurses5.9.

Hope you find this useful :)
