### PR TITLE
Allow candidates to be None

### DIFF
--- a/percol/__init__.py
+++ b/percol/__init__.py
@@ -77,7 +77,7 @@ class Percol(object):
 
         # wraps candidates (iterator)
         from lazyarray import LazyArray
-        re_iterable_candidates = LazyArray(candidates)
+        re_iterable_candidates = LazyArray(candidates or [])
 
         # create model
         self.model_candidate = SelectorModel(percol = self,


### PR DESCRIPTION
Previously, `candidates` argument for `Percol.__init__` must be given
always even if it is an optional argument.

It is one of the point I mentioned in #8.
