### PR TITLE
Fix for zsh-history on oh-my-zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ if exists percol; then
     function percol_select_history() {
         local tac
         exists gtac && tac="gtac" || { exists tac && tac="tac" || { tac="tail -r" } }
-        BUFFER=$(history -n 1 | eval $tac | percol --query "$LBUFFER")
+        BUFFER=$(fc -l -n 1 | eval $tac | percol --query "$LBUFFER")
         CURSOR=$#BUFFER         # move cursor
         zle -R -c               # refresh
     }


### PR DESCRIPTION
Thank you awesome tool! <3
But `zsh-history` doesn't works, when oh-my-zsh set alias `history`.
I fixed README for oh-my-zsh users.
in detail `fc` section on `man zshbuiltins`.
