### PR TITLE
Fix private modules import

### DIFF
--- a/percol/__init__.py
+++ b/percol/__init__.py
@@ -37,14 +37,14 @@ import signal
 import curses
 import threading
 
-import debug, action
+from percol import debug, action
 
-from display import Display
-from finder  import FinderMultiQueryString
-from key     import KeyHandler
-from model   import SelectorModel
-from view    import SelectorView
-from command import SelectorCommand
+from percol.display import Display
+from percol.finder  import FinderMultiQueryString
+from percol.key     import KeyHandler
+from percol.model   import SelectorModel
+from percol.view    import SelectorView
+from percol.command import SelectorCommand
 
 class TerminateLoop(Exception):
     def __init__(self, value):

--- a/percol/display.py
+++ b/percol/display.py
@@ -22,7 +22,7 @@ import types
 import curses
 import re
 
-import markup, debug
+from percol import markup, debug
 
 FG_COLORS = {
     "black"   : curses.COLOR_BLACK,

--- a/percol/finder.py
+++ b/percol/finder.py
@@ -18,7 +18,7 @@
 #
 
 from abc import ABCMeta, abstractmethod
-from lazyarray import LazyArray
+from percol.lazyarray import LazyArray
 
 # ============================================================ #
 # Finder

--- a/percol/key.py
+++ b/percol/key.py
@@ -17,7 +17,7 @@
 # Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 #
 
-import curses, array, debug
+import curses, array
 
 SPECIAL_KEYS = {
     curses.KEY_A1        : "<a1>",

--- a/percol/model.py
+++ b/percol/model.py
@@ -18,8 +18,7 @@
 #
 
 import types
-import display
-import debug
+from percol import display, debug
 
 class SelectorModel(object):
     def __init__(self,

--- a/percol/view.py
+++ b/percol/view.py
@@ -24,7 +24,7 @@ import math
 
 from itertools import islice
 
-import display, debug
+from percol import display, debug
 
 class SelectorView(object):
     def __init__(self, percol = None):


### PR DESCRIPTION
Unexpected modules are loaded if same name modules are already installed
such as `debug.py`(https://github.com/narfdotpl/debug).

I suppose this is related to #16

Please see this patch. I'm not familiar with python programming, please report me
if you find any issues.
