### PR TITLE
add --version option via OptionParser version argument

### DIFF
--- a/percol/cli.py
+++ b/percol/cli.py
@@ -145,7 +145,8 @@ def decide_match_method(options):
         return FinderMultiQueryString
 
 def main():
-    parser = OptionParser(usage = "Usage: %prog [options] [FILE]")
+    from percol import __version__
+    parser = OptionParser(usage = "Usage: %prog [options] [FILE]", version = "%prog {0}".format(__version__))
     setup_options(parser)
     options, args = parser.parse_args()
 


### PR DESCRIPTION
Although, by default without options, `percol` shows a good-looking ASCII art with the version string, but `--version` is nice to have.
