### PR TITLE
create rc file if does not exist

### DIFF
--- a/percol/cli.py
+++ b/percol/cli.py
@@ -58,7 +58,9 @@ def load_rc(percol, path = None, encoding = 'utf-8'):
     if not os.path.exists(path):
         path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'rc.py')
     try:
-        with open(path, 'rb') as file:
+        # If file rc not exist then create new.
+        mode = "rb" if os.path.exists(path) else "wb+"
+        with open(path, mode) as file:
             exec(compile(file.read(), path, 'exec'), locals())
     except Exception as e:
         raise LoadRunCommandFileError(e)


### PR DESCRIPTION
Installed with `sudo pip install percol`
Getting below exception. 
Issue is rc file wan't created. This is patch for this issue.

```
Traceback (most recent call last):
  File "/usr/local/bin/percol", line 32, in <module>
    main()
  File "/usr/local/lib/python2.7/dist-packages/percol/cli.py", line 228, in main
    load_rc(percol, options.rcfile)
  File "/usr/local/lib/python2.7/dist-packages/percol/cli.py", line 65, in load_rc
    raise LoadRunCommandFileError(e)
percol.cli.LoadRunCommandFileError: Error in rc.py: [Errno 2] No such file or directory: '/usr/local/lib/python2.7/dist-packages/percol/rc.py'
```
