### PR TITLE
Allow `reverse` attribute in candidates line style

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ Each RHS is a tuple of style specifiers listed below.
 - `"normal"`     for `curses.A_NORMAL`
 - `"standout"`   for `curses.A_STANDOUT`
 - `"underline"`  for `curses.A_UNDERLINE`
+- `"reverse"`    for `curses.A_REVERSE`
 
 ## Matching Method
 

--- a/percol/display.py
+++ b/percol/display.py
@@ -45,6 +45,7 @@ ATTRS = {
     "normal"     : curses.A_NORMAL,
     "standout"   : curses.A_STANDOUT,
     "underline"  : curses.A_UNDERLINE,
+    "reverse"    : curses.A_REVERSE,
 }
 
 COLOR_COUNT = len(FG_COLORS)


### PR DESCRIPTION
This PR adds support for using `curses.A_REVERSE` attribute when customizing candidates line style.
