### PR TITLE
Allow running as a symlink.

### DIFF
--- a/bin/percol
+++ b/bin/percol
@@ -22,7 +22,7 @@ import os, sys
 
 # add load path
 if __name__ == '__main__':
-    libdir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    libdir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
     if os.path.exists(os.path.join(libdir, "percol")):
         sys.path.insert(0, libdir)
 


### PR DESCRIPTION
If the `percol` executable is a symlink, `abspath` returns the directory
containing the link, while `realpath` returns the directory containing
the target. So now I can create

```
local/bin/percol -> local/src/percol/bin/percol
```

and I don't need local/src/percol/bin in my $PATH.
