### PR TITLE
Change example zsh func to only show unique history matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ if exists percol; then
     function percol_select_history() {
         local tac
         exists gtac && tac="gtac" || { exists tac && tac="tac" || { tac="tail -r" } }
-        BUFFER=$(fc -l -n 1 | eval $tac | percol --query "$LBUFFER")
+        BUFFER=$(fc -l -n 1 | sort -u | eval $tac | percol --query "$LBUFFER")
         CURSOR=$#BUFFER         # move cursor
         zle -R -c               # refresh
     }


### PR DESCRIPTION
This patch keeps the matched history list shorter by filtering out doublings.
