### PR TITLE
add a new matching method 'pinyin' for ease matching against Chinese characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ percol adds flavor of interactive selection to the traditional pipe concept on U
     - [Migemo support](#migemo-support)
         - [Dictionary settings](#dictionary-settings)
         - [Minimum query length](#minimum-query-length)
+    - [Pinyin support](#pinyin-support)
     - [Switching matching method dynamically](#switching-matching-method-dynamically)
 - [Tips](#tips)
     - [Selecting multiple candidates](#selecting-multiple-candidates)
@@ -363,6 +364,17 @@ To change this behavior, change the value of `FinderMultiQueryMigemo.minimum_que
 from percol.finder import FinderMultiQueryMigemo
 FinderMultiQueryMigemo.minimum_query_length = 1
 ```
+
+### Pinyin support
+
+Now percol supports **pinyin** (http://en.wikipedia.org/wiki/Pinyin/) for matching Chinese characters.
+
+    $ percol --match-method pinyin
+
+In this matching method, first char of each Chinese character's pinyin sequence is used for matching.
+For example, 'zw' matches '中文' (ZhongWen), '中午'(ZhongWu), '作为' (ZuoWei) etc.
+
+Extra package pinin(https://pypi.python.org/pypi/pinyin/0.2.5) needed.
 
 ### Switching matching method dynamically
 

--- a/percol/cli.py
+++ b/percol/cli.py
@@ -153,9 +153,12 @@ def decide_match_method(options):
     if options.match_method == "regex":
         from percol.finder import FinderMultiQueryRegex
         return FinderMultiQueryRegex
-    if options.match_method == "migemo":
+    elif options.match_method == "migemo":
         from percol.finder import FinderMultiQueryMigemo
         return FinderMultiQueryMigemo
+    elif options.match_method == "pinyin":
+        from percol.finder import FinderMultiQueryPinyin
+        return FinderMultiQueryPinyin
     else:
         from percol.finder import FinderMultiQueryString
         return FinderMultiQueryString

--- a/percol/finder.py
+++ b/percol/finder.py
@@ -237,3 +237,39 @@ class FinderMultiQueryMigemo(FinderMultiQuery):
             return [(matched.start(), matched.end() - matched.start())]
         except:
             return None
+
+
+# ============================================================ #
+# Finder > AND search > Pinyin support
+# ============================================================ #
+
+class FinderMultiQueryPinyin(FinderMultiQuery):
+    """
+    In this matching method, first char of each Chinese character's
+    pinyin sequence is used for matching. For example, 'zw' matches
+    '中文' (ZhongWen), '中午'(ZhongWu), '作为' (ZuoWei) etc.
+
+    Extra package 'pinyin' needed.
+    """
+    def get_name (self):
+        return "pinyin"
+
+    def find_query (self, needle, haystack):
+        try:
+            import pinyin
+            haystack_py = pinyin.get_initial(haystack, '' )
+            needle_len = len(needle)
+            start = 0
+            result = []
+
+            while True :
+                found = haystack_py.find(needle, start)
+                if found < 0 :
+                    break
+                result.append((found, needle_len))
+                start = found + needle_len
+
+            return result
+        except :
+            return None
+


### PR DESCRIPTION
This add a new matching method `pinyin`. In this matching method, first char of each Chinese character's pinyin sequence is used for matching.  For example, `zw` matches '中文' (ZhongWen), '中午'(ZhongWu), '作为' (ZuoWei) etc.

Extra package [pinyin](https://pypi.python.org/pypi/pinyin) needed.