### PR TITLE
Fix URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ FinderMultiQueryMigemo.minimum_query_length = 1
 
 ### Pinyin support
 
-Now percol supports **pinyin** (http://en.wikipedia.org/wiki/Pinyin/) for matching Chinese characters.
+Now percol supports **pinyin** (http://en.wikipedia.org/wiki/Pinyin) for matching Chinese characters.
 
     $ percol --match-method pinyin
 


### PR DESCRIPTION
Wikipedia doesn't have a valid article at http://en.wikipedia.org/wiki/Pinyin/
this should be a typo.