### PR TITLE
use sys.exit instead of exit from site module

### DIFF
--- a/percol/cli.py
+++ b/percol/cli.py
@@ -167,14 +167,14 @@ def main():
     options, args = parser.parse_args()
 
     if options.peep:
-        exit(1)
+        sys.exit(1)
 
     def exit_program(msg = None, show_help = True):
         if not msg is None:
             print(msg)
         if show_help:
             parser.print_help()
-        exit(1)
+        sys.exit(1)
 
     # get ttyname
     ttyname = options.tty or tty.get_ttyname()
@@ -266,4 +266,4 @@ Maybe all descriptors are redirecred."""))
             else:
                 exit_code = percol.loop()
 
-        exit(exit_code)
+        sys.exit(exit_code)


### PR DESCRIPTION
I'm trying to build this project with pyinstaller and ran into the problem with `exit()` v.s `sys.exit()`
the original code will throw `NameError: name 'exit' is not defined`

according to the official document
https://docs.python.org/2/library/constants.html#exit

we should use `sys.exit()` instead
