### PR TITLE
Change finish_with_exit_code so that it can return value

### DIFF
--- a/percol/__init__.py
+++ b/percol/__init__.py
@@ -258,16 +258,16 @@ class Percol(object):
     # Finish / Cancel
     # ------------------------------------------------------------ #
 
-    def finish(self):
+    def finish(self, value=0):
         # save selected candidates and use them later (in execute_action)
-        raise TerminateLoop(self.finish_with_exit_code())          # success
+        raise TerminateLoop(self.finish_with_exit_code(value))     # success
 
     def cancel(self):
         raise TerminateLoop(self.cancel_with_exit_code())          # failure
 
-    def finish_with_exit_code(self):
+    def finish_with_exit_code(self, value):
         self.args_for_action = self.model_candidate.get_selected_results_with_index()
-        return 0
+        return value
 
     def cancel_with_exit_code(self):
         return 1


### PR DESCRIPTION
The zsh function percol_select_history is so cool!

I want to make it greater by adding branch after finish.
To realize it, I changed finish_with_exit_code so that it can return the value.
Using this feature, you can change the history-search behavior as below.
- If you push enter, zsh accept the history line immediately.
- If you push `C-k`, zsh load the history line but doesn't accept it. You can edit the line after percol finishes.

In your `.zshrc`, put the lines below.
```zsh
percol_select_history() {
    local tac
    exists gtac && tac="gtac" || { exists tac && tac="tac" || { tac="tail -r" } }
    BUFFER=$(fc -l -n 1 | eval $tac | percol --query "$LBUFFER")
    RETURN=$?
    CURSOR=$#BUFFER
    zle -R -c
    test $RETURN -eq 0 && zle accept-line
}
```
In your `rc.py`, put the lines below.
```phtyon
percol.import_keymap({
    "C-j" : lambda percol: percol.finish(),
    "C-k" : lambda percol: percol.finish(value=2),
    })
```
