### PR TITLE
When locale is not initialized, skip setlocale

### DIFF
--- a/percol/cli.py
+++ b/percol/cli.py
@@ -119,7 +119,10 @@ def setup_options(parser):
                       help = "exit immediately with doing nothing to cache module files and speed up start-up time")
 
 def set_proper_locale(options):
-    locale.setlocale(locale.LC_ALL, '')
+    try:
+        locale.setlocale(locale.LC_ALL, '')
+    except Exception as e:
+        debug.log("Exception in setlocale", e)
     output_encoding = locale.getpreferredencoding()
     if options.output_encoding:
         output_encoding = options.output_encoding


### PR DESCRIPTION
When locale is not initialized, locale.setlocale(locale.LC_ALL, '') fails.
In that case, just skip setlocale process. Fixes #93 

# Real World Situation

On Mac, LC_CTYPE is sometimes set to UTF-8. (https://www.cyberciti.biz/faq/os-x-terminal-bash-warning-setlocale-lc_ctype-cannot-change-locale/)

When you ssh to Linux servers, your local machine's LC_CTYPE is used on that remote server.
Since Linux does not recognize `UTF-8` as a proper `LC_CTYPE`, locale initialization fails. If you proceed to run `locale.setlocale(locale.LC_ALL, '')`, you'll encounter errors as described in #93 .

# How To Reproduce The Error

## Linux
```
$ LC_CTYPE=UTF-8 percol
-bash: warning: setlocale: LC_CTYPE: cannot change locale (UTF-8): No such file or directory
Traceback (most recent call last):
  File "/home/ec2-user/demo/bin/percol", line 14, in <module>
    main()
  File "/home/ec2-user/demo/local/lib/python2.7/site-packages/percol/cli.py", line 190, in main
    output_encoding = set_proper_locale(options)
  File "/home/ec2-user/demo/local/lib/python2.7/site-packages/percol/cli.py", line 122, in set_proper_locale
    locale.setlocale(locale.LC_ALL, '')
  File "/home/ec2-user/demo/lib64/python2.7/locale.py", line 581, in setlocale
    return _setlocale(category, locale)
locale.Error: unsupported locale setting
```
## Mac
```
@mac$ LC_CTYPE=UTF-8 ssh REMOTE-SERVER
@linux$ percol
Traceback (most recent call last):
...
```