### PR TITLE
Add --select-ignore option

### DIFF
--- a/percol/cli.py
+++ b/percol/cli.py
@@ -117,6 +117,8 @@ def setup_options(parser):
                       help = "whether quote the output line")
     parser.add_option("--peep", action = "store_true", dest = "peep", default = False,
                       help = "exit immediately with doing nothing to cache module files and speed up start-up time")
+    parser.add_option("--select-ignore", dest="select_ignore",
+                      help="lines that match regex cannot be selected")
 
 def set_proper_locale(options):
     try:
@@ -261,6 +263,9 @@ Maybe all descriptors are redirected."""))
             # view settings from option values
             set_if_not_none(options, percol.view, 'prompt_on_top')
             set_if_not_none(options, percol.view, 'results_top_down')
+            # command settings from options
+            set_if_not_none(options, percol.command_candidate, 'select_ignore')
+            
             # enter main loop
             if options.auto_fail and percol.has_no_candidate():
                 exit_code = percol.cancel_with_exit_code()

--- a/percol/command.py
+++ b/percol/command.py
@@ -1,14 +1,17 @@
 # -*- coding: utf-8 -*-
-
+import re
 import six
+
 
 class SelectorCommand(object):
     """
     Wraps up SelectorModel and provides advanced commands
     """
+
     def __init__(self, model, view):
         self.model = model
         self.view = view
+        self.select_ignore = r''
 
     # ------------------------------------------------------------ #
     # Selection
@@ -16,6 +19,21 @@ class SelectorCommand(object):
 
     # Line
 
+    def delta_next(self, step=1):
+        delta = step
+        while True:
+            line = self.model.get_result(self.model.index + delta)
+            if line is None:
+                return step
+            if not line or self.select_ignore and re.match(
+                    self.select_ignore, line):
+                delta += step
+                continue
+            break
+        return delta
+
+    def delta_prev(self):
+        return self.delta_next(step=-1)
     def select_successor(self):
         self.model.select_index(self.model.index + 1)
 


### PR DESCRIPTION
This MR adds the possibility to give a regex to ignore lines from selection.

In following demo, I set `--select-ignore='^#'` so that comments are skipped in the displayed cheat file  :
[![asciicast](https://asciinema.org/a/DpHLUTU9HVqPhgdP6DuJjSzUr.svg)](https://asciinema.org/a/DpHLUTU9HVqPhgdP6DuJjSzUr)