### PR TITLE
fix concurrency bug with --auto-match (#68)

### DIFF
--- a/percol/__init__.py
+++ b/percol/__init__.py
@@ -55,6 +55,8 @@ class Percol(object):
         # wraps candidates (iterator)
         from percol.lazyarray import LazyArray
         self.candidates = LazyArray(candidates or [])
+        self.has_no_candidate = self.candidates.has_nth_value(0)
+        self.has_only_one_candidate = self.candidates.has_nth_value(0) and not self.candidates.has_nth_value(1)
 
         # create model
         self.model_candidate = SelectorModel(percol = self,
@@ -65,12 +67,6 @@ class Percol(object):
                                           collection = [action.desc for action in actions],
                                           finder = action_finder)
         self.model = self.model_candidate
-
-    def has_no_candidate(self):
-        return not self.candidates.has_nth_value(0)
-
-    def has_only_one_candidate(self):
-        return self.candidates.has_nth_value(0) and not self.candidates.has_nth_value(1)
 
     def __enter__(self):
         # init curses and it's wrapper

--- a/percol/cli.py
+++ b/percol/cli.py
@@ -262,9 +262,9 @@ Maybe all descriptors are redirected."""))
             set_if_not_none(options, percol.view, 'prompt_on_top')
             set_if_not_none(options, percol.view, 'results_top_down')
             # enter main loop
-            if options.auto_fail and percol.has_no_candidate():
+            if options.auto_fail and percol.has_no_candidate:
                 exit_code = percol.cancel_with_exit_code()
-            elif options.auto_match and percol.has_only_one_candidate():
+            elif options.auto_match and percol.has_only_one_candidate:
                 exit_code = percol.finish_with_exit_code()
             else:
                 exit_code = percol.loop()


### PR DESCRIPTION
Fixes #68.

If you call `has_nth_value` while iterating over `candidates` via `LazyArray.__iter__` here:

https://github.com/mooz/percol/blob/d0bc902555fff5abef85012af3cbc323b915843b/percol/lazyarray.py#L27-L30

You can get into a state where elements have been consumed from `source` but you've already exhausted `got_elements`, so it appears the elements are missing.

There's probably a way to fix `LazyArray` so that this isn't possible, but for now this works around the issue by calculating `has_no_candidate` and `has_only_one_candidate` before any other iterations start.