### PR TITLE
Fix #116 Windows support

### DIFF
--- a/percol/debug.py
+++ b/percol/debug.py
@@ -1,7 +1,13 @@
 # -*- coding: utf-8 -*-
 
-import syslog
-syslog.openlog("Percol")
+try:
+    import syslog
+    syslog.openlog("Percol")
+except ImportError:
+    pass
+    # probably windows
+    # https://github.com/mooz/percol/issues/86 why is this debugging by default?
+
 
 def log(name, s = ""):
     syslog.syslog(syslog.LOG_ALERT, str(name) + ": " + str(s))

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+import sys
+
 from setuptools import setup
 
 is_win = sys.platform.startswith('win')

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,12 @@
 
 from setuptools import setup
 
+is_win = sys.platform.startswith('win')
+
+install_requires = ["six >= 1.7.3", "cmigemo >= 0.1.5"]
+if is_win:
+      install_requires += ['windows-curses']
+
 exec(open("percol/info.py").read())
 
 setup(name             = "percol",
@@ -22,5 +28,5 @@ setup(name             = "percol",
                           "Topic :: Utilities"],
       keywords         = "anything.el unite.vim dmenu shell pipe filter curses",
       license          = "MIT",
-      install_requires = ["six >= 1.7.3", "cmigemo >= 0.1.5"]
+      install_requires = install_requires
       )


### PR DESCRIPTION
Addresses #86. Working Windows support as a library (not the `percol` command line tool).